### PR TITLE
Update GetNonexistentFileTest.java

### DIFF
--- a/src/test/java/util/GetNonexistentFileTest.java
+++ b/src/test/java/util/GetNonexistentFileTest.java
@@ -1,4 +1,5 @@
 package util;
+// Импортируем депенденси от рекваетри иммутебл хэшлинкстринг запросов
 
 import org.hyperskill.hstest.v6.common.FileUtils;
 import org.junit.Test;


### PR DESCRIPTION
Добавил важный кусок кода, импортирующий необходимые для корректной работы зависимости и позволяющий пройти тест только при 146% знании темы сопротивления материалов.